### PR TITLE
Ambiguous use of 'toggle()' in Swift 4.2

### DIFF
--- a/Sources/NumberExtensions.swift
+++ b/Sources/NumberExtensions.swift
@@ -20,12 +20,6 @@ public func clamped<T>(_ value: T, _ range: ClosedRange<T>) -> T {
 
 public extension Bool {
     
-    @discardableResult
-    public mutating func toggle() -> Bool {
-        self = !self
-        return self
-    }
-    
     public func toggled() -> Bool {
         return !self
     }


### PR DESCRIPTION
toggle() was implemented for booleans in Swift 4.2